### PR TITLE
Update README.md to use link to file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `Platform Security Workflow` uses the free and open-source security tools An
 
 ## Getting Started
 
-Getting started with the `Platform Security Github Workflow` is as easy as copying the `security-workflow-template.yml` file from this repository and adding it to your GitHub repository's `.github/workflows` directory. Doing so will enable security scanning (via our reusable GitHub workflow) anytime a Pull-Request is opened or merged.
+Getting started with the `Platform Security Github Workflow` is as easy as copying the [security-workflow-template.yml](https://github.com/RedHatInsights/platform-security-gh-workflow/blob/master/security-workflow-template.yml) file from this repository and adding it to your GitHub repository's `.github/workflows` directory. Doing so will enable security scanning (via our reusable GitHub workflow) anytime a Pull-Request is opened or merged.
 
 After the workflow has run, you can download artifacts of the results from the associated `workflow run`. The artifacts will contain the following files:
 


### PR DESCRIPTION
Change the reference to security-workflow-template.yml to be a link to the file in the root of the repo, since the file also exists in the `.github/workflow` folder as well.